### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 `just-prompt` is a Model Control Protocol (MCP) server that provides a unified interface to various Large Language Model (LLM) providers including OpenAI, Anthropic, Google Gemini, Groq, DeepSeek, and Ollama. See how we use the `ceo_and_board` tool to make [hard decisions easy with o3 here](https://youtu.be/LEMLntjfihA).
 
+<a href="https://glama.ai/mcp/servers/@disler/just-prompt">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@disler/just-prompt/badge" alt="Just Prompt MCP server" />
+</a>
+
 <img src="images/just-prompt-logo.png" alt="Just Prompt Logo" width="700" height="auto">
 
 <img src="images/o3-as-a-ceo.png" alt="Just Prompt Logo" width="700" height="auto">
@@ -279,8 +283,7 @@ Examples:
 * `openai:o4-mini:low`
 * `o:o4-mini:high`
 
-When a reasoning suffix is present, **just‑prompt** automatically switches to
-the OpenAI *Responses* API (when available) and sets the corresponding
+When a reasoning suffix is present, **just‑prompt** automatically switches to the OpenAI *Responses* API (when available) and sets the corresponding
 `reasoning.effort` parameter.  If the installed OpenAI SDK is older, it
 gracefully falls back to the Chat Completions endpoint and embeds an internal
 system instruction to approximate the requested effort level.


### PR DESCRIPTION
This PR adds a badge for the [Just Prompt](https://glama.ai/mcp/servers/@disler/just-prompt) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@disler/just-prompt">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@disler/just-prompt/badge" alt="Just Prompt MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.