### PR TITLE
Fix Gemini models listing by updating API calls

### DIFF
--- a/src/just_prompt/atoms/llm_providers/gemini.py
+++ b/src/just_prompt/atoms/llm_providers/gemini.py
@@ -169,9 +169,9 @@ def list_models() -> List[str]:
         
         # Get the list of models
         models = []
-        available_models = client.list_models()
+        available_models = client.models.list()
         for m in available_models:
-            if "generateContent" in m.supported_generation_methods:
+            if "generateContent" in m.supported_actions:
                 models.append(m.name)
                 
         # Format model names - strip the "models/" prefix if present


### PR DESCRIPTION
- Replace client.list_models() with client.models.list()
- Change supported_generation_methods to supported_actions
- Now returns all 40+ available Gemini models instead of falling back to hardcoded list